### PR TITLE
Convert Discord message processing from polling to WebSocket

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -16,7 +16,7 @@ import '@mantine/notifications/styles.css';
 import '@mantine/spotlight/styles.css';
 import { CustomSpotlight } from './mantine/spotlight.tsx';
 
-// Start the Discord polling service instead of realtime service
+// Start the Discord message service (uses Realtime WebSocket)
 discordPollingService.start();
 settlementPopulationService.start();
 

--- a/src/services/discordPollingService.ts
+++ b/src/services/discordPollingService.ts
@@ -1,22 +1,67 @@
-// Discord polling service - calls Edge Function to process messages securely
+// Discord message service - uses Supabase Realtime to trigger Edge Function processing
 // The Edge Function uses the service role key server-side for secure database updates
 
+import { RealtimeChannel } from '@supabase/supabase-js';
 import { supabaseClient } from '../supabase/supabaseClient';
 
 class DiscordPollingService {
-  private intervalId: number | null = null;
+  private subscription: RealtimeChannel | null = null;
   private isProcessing = false;
+  private debounceTimer: ReturnType<typeof setTimeout> | null = null;
+  private fallbackIntervalId: ReturnType<typeof setInterval> | null = null;
+
+  // Debounce delay in ms - wait this long after last message before processing
+  private readonly DEBOUNCE_DELAY = 1000;
+  // Fallback interval in ms - check for missed messages periodically
+  private readonly FALLBACK_INTERVAL = 60000;
 
   start() {
-    console.log('🔄 Starting Discord message polling service...');
+    console.log('🔄 Starting Discord message service with Realtime...');
 
-    // Check for messages every 5 seconds
-    this.intervalId = window.setInterval(() => {
-      this.processMessages();
-    }, 5000);
+    // Subscribe to new messages in discord_message_log
+    this.subscription = supabaseClient
+      .channel('discord_message_queue')
+      .on(
+        'postgres_changes',
+        {
+          event: 'INSERT',
+          schema: 'public',
+          table: 'discord_message_log',
+        },
+        (payload) => {
+          console.log('📨 New Discord message queued:', payload.new);
+          this.scheduleProcessing();
+        }
+      )
+      .subscribe((status) => {
+        if (status === 'SUBSCRIBED') {
+          console.log('✅ Discord Realtime subscription active');
+        } else if (status === 'CHANNEL_ERROR') {
+          console.error('❌ Discord Realtime subscription error');
+        } else if (status === 'TIMED_OUT') {
+          console.warn('⏰ Discord Realtime subscription timed out, will retry...');
+        }
+      });
 
-    // Also check immediately
+    // Process any pending messages immediately on start
     this.processMessages();
+
+    // Set up a fallback interval to catch any missed messages
+    this.fallbackIntervalId = setInterval(() => {
+      this.processMessages();
+    }, this.FALLBACK_INTERVAL);
+  }
+
+  // Debounce processing to batch rapid inserts
+  private scheduleProcessing() {
+    if (this.debounceTimer) {
+      clearTimeout(this.debounceTimer);
+    }
+
+    this.debounceTimer = setTimeout(() => {
+      this.processMessages();
+      this.debounceTimer = null;
+    }, this.DEBOUNCE_DELAY);
   }
 
   async processMessages() {
@@ -36,21 +81,37 @@ class DiscordPollingService {
       }
 
       if (data?.processed > 0) {
-        console.log(`📨 Processed ${data.processed} Discord messages (${data.successCount} success, ${data.errorCount} errors)`);
+        console.log(
+          `📨 Processed ${data.processed} Discord messages (${data.successCount} success, ${data.errorCount} errors)`
+        );
       }
     } catch (error) {
-      console.error('❌ Error in Discord polling service:', error);
+      console.error('❌ Error in Discord message service:', error);
     } finally {
       this.isProcessing = false;
     }
   }
 
   stop() {
-    if (this.intervalId) {
-      clearInterval(this.intervalId);
-      this.intervalId = null;
-      console.log('🛑 Discord polling service stopped');
+    // Clean up Realtime subscription
+    if (this.subscription) {
+      supabaseClient.removeChannel(this.subscription);
+      this.subscription = null;
     }
+
+    // Clean up debounce timer
+    if (this.debounceTimer) {
+      clearTimeout(this.debounceTimer);
+      this.debounceTimer = null;
+    }
+
+    // Clean up fallback interval
+    if (this.fallbackIntervalId) {
+      clearInterval(this.fallbackIntervalId);
+      this.fallbackIntervalId = null;
+    }
+
+    console.log('🛑 Discord message service stopped');
   }
 }
 


### PR DESCRIPTION
## Summary
- Replace 5-second interval polling with Supabase Realtime WebSocket subscription
- Significantly reduces network traffic and cleans up the browser Network tab

## Changes
- **`src/services/discordPollingService.ts`** - Rewrote to use Supabase Realtime
  - Subscribes to INSERT events on `discord_message_log` table
  - 1-second debounce to batch rapid message inserts
  - 60-second fallback interval (down from 5 seconds) to catch missed messages
  - Proper cleanup of subscription, timers on stop
- **`src/main.tsx`** - Updated comment

## Benefits
| Metric | Before | After |
|--------|--------|-------|
| Network requests | ~720/hour | ~60/hour |
| Connection type | Repeated HTTP | Single WebSocket |
| Message detection | Up to 5s delay | Near-instant |

## Test plan
- [x] Verified Realtime subscription connects successfully
- [x] Verified messages are processed when queued
- [x] Verified Network tab shows WebSocket instead of polling requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)