### PR TITLE
Restrict user deletion to super_admin only

### DIFF
--- a/src/views/Settings.tsx
+++ b/src/views/Settings.tsx
@@ -283,17 +283,9 @@ export function Settings() {
     const currentUserRole = userProfile.role.name.toLowerCase();
     const targetUserRole = targetUser.role?.name?.toLowerCase();
 
-    // Super admin can delete anyone except other super admins
+    // Only super admin can delete users (except other super admins)
     if (currentUserRole === 'super_admin') {
       return targetUserRole !== 'super_admin';
-    }
-
-    // Admin can delete users with no role or regular users, but not admins or super_admins
-    if (currentUserRole === 'admin') {
-      return (
-        !targetUserRole ||
-        (targetUserRole !== 'admin' && targetUserRole !== 'super_admin')
-      );
     }
 
     return false;


### PR DESCRIPTION
## Summary
- Remove admin ability to delete users from the Settings page
- Only super_admin users can now delete other users
- Simplifies the `canDeleteUser` function by removing the admin role check

## Test plan
- [x] Log in as an admin user and verify the delete button is no longer visible for any users
- [ ] Log in as a super_admin and verify delete functionality still works for non-super_admin users
- [ ] Verify super_admin still cannot delete other super_admin users

🤖 Generated with [Claude Code](https://claude.com/claude-code)